### PR TITLE
Changed "core contributors" to "top contributors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is inspired by the [React RFC repo](https://github.com/reactjs/rfcs), but tod
 
 ### Core Meetings
 
-The top contributors regularly meets to discuss ongoing problems with the goal of drafting solution proposals. The [core meetings](core-meetings/README.md) directory contains meeting notes and topics for this process.
+The top contributors regularly meet to discuss ongoing problems with the goal of drafting solution proposals. The [core meetings](core-meetings/README.md) directory contains meeting notes and topics for this process.
 
 ## CoC
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is inspired by the [React RFC repo](https://github.com/reactjs/rfcs), but tod
 
 ### Core Meetings
 
-The core team regularly meets to discuss ongoing problems with the goal of drafting solution proposals. The [core meetings](core-meetings/README.md) directory contains meeting notes and topics for this process.
+The top contributors regularly meets to discuss ongoing problems with the goal of drafting solution proposals. The [core meetings](core-meetings/README.md) directory contains meeting notes and topics for this process.
 
 ## CoC
 


### PR DESCRIPTION
I think the term "top contributors" may be more representative. The core members are just folks who have been contributing to the framework, and by calling them top contributors, we show how we could someone could become a part of the "core" group.