### PR TITLE
Extract CLI from core

### DIFF
--- a/proposals/0002-Extracted-Command-Line-Tools.md
+++ b/proposals/0002-Extracted-Command-Line-Tools.md
@@ -5,7 +5,7 @@ author:
 date: 2018-08-10
 ---
 
-# RFC0000: Extract CLI from Core
+# RFC0003: Extract CLI from Core
 
 ## Summary
 
@@ -33,7 +33,13 @@ Extracting it out would be the first step to make React Native CLI agnostic, all
 
 ## Detailed design
 
-The goal of this proposal is to extract the CLI out of the React Native repository into a separate project, called `react-native-cli`, that would become a direct dependency of React Native. It is similar to the extraction process of `Metro`.
+The goal of this proposal is to extract the CLI out of the React Native repository into a separate project, called `react-native-cli`, that would become a direct dependency of React Native. It is similar to the extraction process of `Metro`. 
+
+That includes moving out two folders: 
+- `local-cli`, where business logic of the CLI and all available commands are located
+- `react-native-cli`, where global package for running `react-native init` lives
+
+Development of these two packages would take place under one repository.
 
 Since `metro` isn't required anywhere else outside of `local-cli` folder (where the business logic of the CLI is located), it would be removed from the React Native dependencies and become the depdendency of newly created `react-native-cli`.
 


### PR DESCRIPTION
This proposes that we extract CLI from the core of React Native into a separate module and describes the rationale behind such a decision.

I have tried to describe as much in details as possible how I'd see this process to look like, but if you have any additional questions, let me know.

We also have an upcoming meeting regarding CLI itself this month, whoever would like to join that doesn't have an invite yet, let me know.