### PR TITLE
Rename RFCs to match PR number

### DIFF
--- a/proposals/0003-webview.md
+++ b/proposals/0003-webview.md
@@ -5,7 +5,7 @@ author:
 date: 2018-07-30
 ---
 
-# RFC0001: Extract WebView From Core
+# RFC0003: Extract WebView From Core
 
 ## Summary
 

--- a/proposals/0011-Turbo-Modules.md
+++ b/proposals/0011-Turbo-Modules.md
@@ -1,4 +1,4 @@
-# RFC0002: Turbo Modules ™ 
+# RFC0011: Turbo Modules ™ 
 _It's blazing fast_
 
 ## Summary

--- a/proposals/0013-Extracted-Command-Line-Tools.md
+++ b/proposals/0013-Extracted-Command-Line-Tools.md
@@ -5,7 +5,7 @@ author:
 date: 2018-08-10
 ---
 
-# RFC0003: Extract CLI from Core
+# RFC0013: Extract CLI from Core
 
 ## Summary
 

--- a/proposals/0018-cocoapods-support-improvements.md
+++ b/proposals/0018-cocoapods-support-improvements.md
@@ -6,7 +6,7 @@ author:
 date: 2018-08-15
 ---
 
-# RFC0004: CocoaPods Support Improvements
+# RFC0018: CocoaPods Support Improvements
 
 ## Summary
 

--- a/proposals/0036-Official-Docker.md
+++ b/proposals/0036-Official-Docker.md
@@ -5,7 +5,7 @@ author:
 date: 2018-10-5
 ---
 
-# RFC0005: Official Android Docker for React Native
+# RFC0036: Official Android Docker for React Native
 
 ## Summary
 

--- a/proposals/0054-a11y-roles-states-improvements.md
+++ b/proposals/0054-a11y-roles-states-improvements.md
@@ -5,6 +5,8 @@ author:
 date: 2019-02-06
 ---
 
+# RFC0054: Improvements to `accessibilityRole` and `accessibilityStates`
+
 ## Summary
 
 Some brilliant work was begun to add cross platform support for accessibility roles and states to React Native. We propose to add some additional roles and states, as well as extend the implementation on Android and Fire OS.

--- a/proposals/0055-a11y-actions.md
+++ b/proposals/0055-a11y-actions.md
@@ -1,10 +1,11 @@
----title: Accessibility Actions Support
+---
+title: Accessibility Actions Support
 author:
 - Marc Mulcahy
 date: 2018-10-31
 ---
 
-# RFC0000: Accessibility Actions Support
+# RFC0055: Accessibility Actions Support
 
 ## Summary
 


### PR DESCRIPTION
Following [this discussion on #86](https://github.com/react-native-community/discussions-and-proposals/pull/86#issuecomment-456305199), and given we have another occurrence of a number gap in `proposals/`, this PR:

- Renames all existing RFCs in `proposals/` to match the originally submitted PR number.
  - Note that this reorders files from before — now in the order of PR submission rather than proposal acceptance.
- Minor formatting fix and insertion of title across files for consistency.

<img width="372" alt="image" src="https://user-images.githubusercontent.com/2547783/196202231-8a13038c-c7ef-4507-8322-b34666052907.png">

