### PR TITLE
Add onPaste to TextInput

### DIFF
--- a/proposals/0000-textinput-onpaste.md
+++ b/proposals/0000-textinput-onpaste.md
@@ -1,0 +1,58 @@
+---
+title: Add onPaste to TextInput
+author:
+    - Abdelhafidh Belalia
+date: 2024-07-18
+---
+
+# RFC0000: Add onPaste to TextInput
+
+## Summary
+
+Add `onPaste` prop to `TextInput` component
+
+## Basic example
+
+```js
+<TextInput onPaste={() => console.log("User pressed Paste")} />
+```
+
+## Motivation
+
+Detect `Paste` event on TextInput. In our use case detecting paste event can be used to support image pasting.
+
+## Detailed design
+
+iOS:
+
+1. In `RCTUITextField`/`RCTUITextView` override the `paste:` method to call the delegate adapater `[didPaste]`
+2. Implement the `didPaste` method on the delegate adapater and call the delegate input `[textInputDidPaste]`
+3. Implement the `textInputDidPaste` method on the delegate input to disptach the `onPaste` event
+
+Android:
+
+1. In `ReactEditText` override the `onTextContextMenuItem` method to call the `PasteWatcher` insatnce
+2. In `ReactTextInputManager` create and set the `PasteWatcher` instance for the view (`ReactEditText`)
+3. Implement the `PasteWatcher` class to to disptach the `onPaste` event
+
+There is a PR for that change already https://github.com/facebook/react-native/pull/45425
+
+## Drawbacks
+
+-   onPaste callback timing is not the same in iOS vs Android. In iOS `onPaste` is called first then `onChange`. While in Android it's the other way around.
+
+## Alternatives
+
+None
+
+## Adoption strategy
+
+This is not a breaking change. Developers can adopt the feature by simply adding `onPaste` prop to their components
+
+## How we teach this
+
+Update the docs https://github.com/facebook/react-native-website/pull/4161
+
+## Unresolved questions
+
+-   How to resolve the timing inconsistency? (Not a blocker)

--- a/proposals/0000-textinput-onpaste.md
+++ b/proposals/0000-textinput-onpaste.md
@@ -14,7 +14,23 @@ Add `onPaste` prop to `TextInput` component
 ## Basic example
 
 ```js
-<TextInput onPaste={() => console.log("User pressed Paste")} />
+<TextInput
+	onPaste={(e) => {
+		const clipboardContent = e.nativeEvent.items[0];
+
+		if (clipboardContent.type === "text/plain") {
+			console.log(`Pasting text: ${clipboardContent.data}`);
+			return;
+		}
+
+		const file = {
+			uri: clipboardContent.data,
+			type: clipboardContent.type,
+		};
+		console.log("Uploading file");
+		uploadFile(file);
+	}}
+/>
 ```
 
 ## Motivation

--- a/proposals/0000-textinput-onpaste.md
+++ b/proposals/0000-textinput-onpaste.md
@@ -23,8 +23,11 @@ Add `onPaste` prop to `TextInput` component
 			return;
 		}
 
+		const fileURI = clipboardContent.data;
+		const fileName = fileURI.split("/").pop();
 		const file = {
-			uri: clipboardContent.data,
+			uri: fileURI,
+			name: fileName,
 			type: clipboardContent.type,
 		};
 		console.log("Uploading file");
@@ -65,11 +68,13 @@ Android:
 
 ### onPaste event
 
-Invoked when the user performs the paste action. The `items` array contains one object where `type` and `data` are the MIME type and the content of the clipboard respectively. `data` is in plaintext if the type is `text/plain`, data URI (base64-encoded) otherwise.
+Invoked when the user performs the paste action. The `items` array contains one object where `type` and `data` are the MIME type and the content of the clipboard respectively. `data` is in plaintext if the type is `text/plain`, URI otherwise.
 
 | Type                                                      |
 | --------------------------------------------------------- |
 | (`{nativeEvent: {target, items: [{type, data}]}`) => void |
+
+Note: On iOS the clipboard items do not expose any URI. When a file is pasted, we copy its data into a temporarily file and provide that file's URI instead.
 
 ## Drawbacks
 

--- a/proposals/0000-textinput-onpaste.md
+++ b/proposals/0000-textinput-onpaste.md
@@ -39,7 +39,7 @@ There is a PR for that change already https://github.com/facebook/react-native/p
 
 ## Drawbacks
 
--   onPaste callback timing is not the same in iOS vs Android. In iOS `onPaste` is called first then `onChange`. While in Android it's the other way around.
+None
 
 ## Alternatives
 
@@ -55,4 +55,4 @@ Update the docs https://github.com/facebook/react-native-website/pull/4161
 
 ## Unresolved questions
 
--   How to resolve the timing inconsistency? (Not a blocker)
+-   onPaste event does not expose any clipboard data. How can we add such data?

--- a/proposals/0000-textinput-onpaste.md
+++ b/proposals/0000-textinput-onpaste.md
@@ -19,9 +19,21 @@ Add `onPaste` prop to `TextInput` component
 
 ## Motivation
 
-Detect `Paste` event on TextInput. In our use case detecting paste event can be used to support image pasting.
+Detect `Paste` event on TextInput. This can be used to support image pasting.
 
 ## Detailed design
+
+1:1 PR https://github.com/facebook/react-native/pull/45425
+
+### Allow pasting images
+
+iOS:
+
+1. In `RCTUITextField`/`RCTUITextView` override the `canPerformAction:` method to return `YES` if the action is paste and the clipboard has images
+
+Android: N/A (already allowed)
+
+### Detecting paste
 
 iOS:
 
@@ -35,11 +47,17 @@ Android:
 2. In `ReactTextInputManager` create and set the `PasteWatcher` instance for the view (`ReactEditText`)
 3. Implement the `PasteWatcher` class to to disptach the `onPaste` event
 
-There is a PR for that change already https://github.com/facebook/react-native/pull/45425
+### onPaste event
+
+Invoked when the user performs the paste action. The `items` array contains one object where `type` and `data` are the MIME type and the content of the clipboard respectively. `data` is in plaintext if the type is `text/plain`, data URI (base64-encoded) otherwise.
+
+| Type                                                      |
+| --------------------------------------------------------- |
+| (`{nativeEvent: {target, items: [{type, data}]}`) => void |
 
 ## Drawbacks
 
-None
+-   Implementation cost: If the clipboard contains an image, the whole image is read in memory and encoded to base64
 
 ## Alternatives
 
@@ -55,4 +73,6 @@ Update the docs https://github.com/facebook/react-native-website/pull/4161
 
 ## Unresolved questions
 
--   onPaste event does not expose any clipboard data. How can we add such data?
+-   Android: Pasting text using the clipboard suggestion option does not trigger the onPaste event
+
+<video src="https://github.com/user-attachments/assets/01911237-3956-4fbe-a37d-152f83331cf5" />

--- a/proposals/0000-textinput-onpaste.md
+++ b/proposals/0000-textinput-onpaste.md
@@ -78,7 +78,7 @@ Note: On iOS the clipboard items do not expose any URI. When a file is pasted, w
 
 ## Drawbacks
 
--   Implementation cost: If the clipboard contains an image, the whole image is read in memory and encoded to base64
+-   iOS: Pasted image is copied into a temporarily file
 
 ## Alternatives
 


### PR DESCRIPTION
Proposal on adding `onPaste` prop to `TextInput` component to detect paste event. [View rendered proposal](https://github.com/s77rt/discussions-and-proposals/blob/TextInput-onPaste/proposals/0000-textinput-onpaste.md)