### PR TITLE
Rename macro to compile out legacy architecture

### DIFF
--- a/proposals/0929-legacy-architecture-removal.md
+++ b/proposals/0929-legacy-architecture-removal.md
@@ -286,12 +286,12 @@ The following symbols are due for removal:
 
 ### C++
 
-In C++ we use the `RCT_FIT_RM_OLD_RUNTIME` macro to annotate classes that are due for removal.
+In C++ we use the `RCT_REMOVE_LEGACY_ARCH` macro to annotate classes that are due for removal.
 
 If a class or a symbol is wrapped inside a:
 
 ```c++
-#ifndef RCT_FIT_RM_OLD_RUNTIME
+#ifndef RCT_REMOVE_LEGACY_ARCH
 ...
 #endif
 ```


### PR DESCRIPTION
The project to remove the legacy architecture is called react fit. We do not want the codename to permeate the codebase. So, let's just rename this macro to RCT_REMOVE_LEGACY_ARCH.

<!--
Hello there!
Thanks for deciding to start a proposal about React Native and how it could evolve for the better!

Given that most of the discussion will be held around the file you are submitting, use this space to simply give a brief introduction to the subject of the PR.
-->